### PR TITLE
Share handler state with delegates, prevent initially/finally

### DIFF
--- a/packages/fx/examples/node-server/index.ts
+++ b/packages/fx/examples/node-server/index.ts
@@ -1,15 +1,14 @@
-import { IncomingMessage, ServerResponse } from 'http'
 
 import { Env, Fail, Log, Resource, Run, Time, fx } from '../../src'
 
-import { serve } from './serve'
+import { Connection, serve } from './serve'
 
 // ----------------------------------------------------------------------
 // Define the handler for requests
-const myHandler = (req: IncomingMessage, res: ServerResponse) => fx(function* () {
-  yield* Log.info(`Received request`, { method: req.method, url: req.url })
-  res.writeHead(200, { 'Content-Type': 'text/plain' })
-  res.end(`ok`)
+const myHandler = ({ request, response }: Connection) => fx(function* () {
+  yield* Log.info(`Received request`, { method: request.method, url: request.url })
+  response.writeHead(200, { 'Content-Type': 'text/plain' })
+  response.end(`ok`)
 })
 
 // ----------------------------------------------------------------------

--- a/packages/fx/examples/node-server/serve.ts
+++ b/packages/fx/examples/node-server/serve.ts
@@ -6,14 +6,19 @@ import { Async, Env, Fail, Fork, Fx, Resource, fx, sync } from '../../src'
 // Run a server, using the provided handler to process requests
 // TODO: Refine and add to a package?
 
+export type Connection = { request: IncomingMessage; response: ServerResponse }
+
 export const serve = <E, A>(
-  handle: (req: IncomingMessage, res: ServerResponse) => Fx<E, A>
+  handle: (c: Connection) => Fx<E, A>
 ) => Resource.bracket(
   fx(function* () {
     const { port } = yield* Env.get<{ port: number} >()
     return createServer().listen(port)
   }),
-  (server) => sync(() => void server.close()),
+  (server) => sync(() => {
+    console.log('close server')
+    server.close()
+  }),
   (server) => fx(function* () {
     // TODO: What is the right way to handle errors and other events?
     let error: Error | undefined
@@ -22,13 +27,13 @@ export const serve = <E, A>(
     const close = () => server.close()
 
     while (!error) {
-      const { request, response } = yield* Async.run((signal) => {
+      const connection = yield* Async.run((signal) => {
         signal.addEventListener('abort', close)
         return nextRequest(server)
       })
 
       if (error) break
-      yield* Fork.fork(handle(request, response))
+      yield* Fork.fork(handle(connection))
     }
 
     if (error) yield* Fail.fail(error)

--- a/packages/fx/src/effects/env.ts
+++ b/packages/fx/src/effects/env.ts
@@ -1,5 +1,5 @@
 import { Effect, Fx, fx, ok } from '../fx'
-import { handle, resume } from '../handler/handler'
+import { handle, resume } from '../handler'
 
 // void | E allows the arg to be omitted while
 // still exposing E in the return type

--- a/packages/fx/src/effects/fail.ts
+++ b/packages/fx/src/effects/fail.ts
@@ -1,6 +1,5 @@
 import { Effect, Fx, fx, ok } from '../fx'
-// eslint-disable-next-line import/no-cycle
-import { control, done, resume } from '../handler/handler'
+import { control, done, resume } from '../handler'
 
 export class Fail<const E> extends Effect('fx/Fail.Fail')<E, never> { }
 

--- a/packages/fx/src/effects/log.ts
+++ b/packages/fx/src/effects/log.ts
@@ -1,5 +1,5 @@
 import { Effect, Fx, fx, ok } from '../fx'
-import { handle, resume } from '../handler/handler'
+import { handle, resume } from '../handler'
 
 import { now } from './time'
 

--- a/packages/fx/src/effects/resource.ts
+++ b/packages/fx/src/effects/resource.ts
@@ -1,5 +1,5 @@
 import { Effect, Fx, fx, is, ok } from '../fx'
-import { control, resume } from '../handler/handler'
+import { control, resume } from '../handler'
 
 import { Fail, catchFail, fail } from './fail'
 

--- a/packages/fx/src/effects/time.ts
+++ b/packages/fx/src/effects/time.ts
@@ -1,5 +1,6 @@
 import { Effect, Fx, ok } from '../fx'
-import { handle, resume } from '../handler/handler'
+import { handle } from '../handler/handler'
+import { resume } from '../handler/step'
 
 export class Now extends Effect('fx/Time.Now')<void, number> { }
 

--- a/packages/fx/src/handler/context.ts
+++ b/packages/fx/src/handler/context.ts
@@ -1,8 +1,17 @@
-import { FxIterable } from '../fx'
+import { EffectType, FxIterable } from "../fx"
 
-export type AnyHandler = {
+import { StateVar } from './internal/state'
+
+export type HandlerContext = Readonly<{
+  handler: AnyHandler
+  state: StateVar
+  forkable: boolean
+}>
+
+export type AnyHandler = Readonly<{
+  effects: readonly EffectType[]
   initially?: undefined | FxIterable<unknown, unknown>
   handle: (e: any, s: any) => FxIterable<unknown, unknown>
   return?: undefined | ((r: any, s: any) => unknown)
   finally?: undefined | ((s: any) => FxIterable<unknown, unknown>)
-}
+}>

--- a/packages/fx/src/handler/handler.ts
+++ b/packages/fx/src/handler/handler.ts
@@ -1,22 +1,9 @@
 // eslint-disable-next-line import/no-cycle
-import { Fork } from '../effects/fork/fork'
-import { EffectType, Fx, FxIterable, is } from '../fx'
-import { pipe } from '../pipe'
+import { Fx, FxIterable } from '../fx'
 
-export type Step<A, R, S> = Resume<A, S> | Return<R>
-export type Resume<A, S = void> = { tag: 'resume', value: A, state: S }
-export type Return<A> = { tag: 'return', value: A }
-
-export function resume<const A>(a: A): Resume<A>
-export function resume<const A, const S>(a: A, s: S): Resume<A, S>
-export function resume<const A, const S>(a: A, s?: S): Resume<A, void | S> {
-  return ({ tag: 'resume', value: a, state: s }) as const
-}
-
-export const done = <const A>(a: A): Step<never, A, never> => ({ tag: 'return', value: a })
-
-export type Effects = readonly EffectType[]
-export type Instance<E extends Effects> = InstanceType<E[number]>
+import { Effects, Handler, Instance } from './internal/handler'
+import { empty } from './internal/state'
+import { Resume, Step } from './step'
 
 export function control<const E1, const R1, const E extends Effects, const SE, const FE, const S, const A, const E2, const R2, const R>(
   f: FxIterable<E1, R1>,
@@ -87,7 +74,7 @@ export function control<const E1, const R1, const E extends Effects, const SE, c
     return?: (r: R1 | R2, s: S) => R
     finally?: (s: S) => FxIterable<FE, void>
   }): Fx<SE | Exclude<E1, Instance<E>> | E2 | FE, R1 | R2 | R> {
-    return new Handler(f, handler, true)
+    return new Handler(f, handler, empty(), false)
   }
 
 export function handle<const E1, const R1, const E extends Effects, const SE, const FE, const S, const A, const E2, const R>(
@@ -159,77 +146,5 @@ export function handle<const E1, const R1, const E extends Effects, const SE, co
     return?: (r: R1, s: S) => R
     finally?: (s: S) => FxIterable<FE, void>
   }): Fx<SE | Exclude<E1, Instance<E>> | E2 | FE, R1 | R> {
-    return new Handler(f, handler, true)
+    return new Handler(f, handler, empty(), true)
   }
-
-const matches = <const E extends Effects, const T>(e: E, t: T): t is Instance<E> =>
-  e.some(effectType => (t as any).id === effectType.id)
-
-class Handler implements Fx<unknown, unknown> {
-  effects: readonly EffectType[]
-  initially: undefined | FxIterable<unknown, unknown> | undefined
-  handle: (e: any, s: any) => FxIterable<unknown, unknown>
-  return: undefined | ((r: any, s: any) => unknown)
-  finally: undefined | ((s: any) => FxIterable<unknown, unknown>)
-
-  constructor(
-    public readonly fx: FxIterable<unknown, unknown>,
-    handler: AnyHandler,
-    public readonly forkable: boolean,
-  ) {
-    this.effects = handler.effects
-    this.initially = handler.initially
-    this.handle = handler.handle
-    this.return = handler.return
-    this.finally = handler.finally
-  }
-
-  // eslint-disable-next-line prefer-rest-params
-  pipe() { return pipe(this, arguments) }
-
-  *[Symbol.iterator]() {
-    const i = this.fx[Symbol.iterator]()
-    let state
-
-    try {
-      state = this.initially ? (yield* this.initially) : undefined
-      let ir = i.next()
-
-      while (!ir.done) {
-        if (matches(this.effects, ir.value)) {
-          const hr: Step<any, any, any> = yield* this.handle((ir.value), state as never) as any
-          switch (hr.tag) {
-            case 'return':
-              return this.return ? this.return(hr.value, state as never) : hr.value
-            case 'resume':
-              state = hr.state
-              ir = i.next(hr.value)
-              break
-          }
-        }
-        else if (is(Fork, ir.value))
-          ir = i.next(yield new Fork(ir.value.arg, [...ir.value.context, { handler: this, state }]))
-        else
-          ir = i.next(yield ir.value as any)
-      }
-
-      return this.return ? this.return(ir.value, state as never) : ir.value
-    } finally {
-      if (i.return) i.return()
-      if (this.finally) yield* this.finally(state as never)
-    }
-  }
-}
-
-export type HandlerContext = {
-  handler: Handler
-  state: unknown
-}
-
-export type AnyHandler = {
-  effects: readonly EffectType[]
-  initially?: undefined | FxIterable<unknown, unknown>
-  handle: (e: any, s: any) => FxIterable<unknown, unknown>
-  return?: undefined | ((r: any, s: any) => unknown)
-  finally?: undefined | ((s: any) => FxIterable<unknown, unknown>)
-}

--- a/packages/fx/src/handler/index.ts
+++ b/packages/fx/src/handler/index.ts
@@ -1,0 +1,3 @@
+export * from './context'
+export * from './handler'
+export * from './step'

--- a/packages/fx/src/handler/internal/handler.ts
+++ b/packages/fx/src/handler/internal/handler.ts
@@ -1,0 +1,61 @@
+// eslint-disable-next-line import/no-cycle
+import { Fork } from '../../effects/fork/fork'
+import { EffectType, Fx, FxIterable, is } from '../../fx'
+import { pipe } from '../../pipe'
+import { AnyHandler } from '../context'
+import { Step } from '../step'
+
+import { StateVar } from './state'
+
+export class Handler implements Fx<unknown, unknown> {
+  constructor(
+    public readonly fx: FxIterable<unknown, unknown>,
+    public readonly handler: AnyHandler,
+    public readonly state: StateVar,
+    public readonly forkable: boolean
+  ) { }
+
+  // eslint-disable-next-line prefer-rest-params
+  pipe() { return pipe(this, arguments) }
+
+  *[Symbol.iterator]() {
+    const { handler, state, forkable, fx } = this
+    const i = fx[Symbol.iterator]()
+
+    try {
+      state.value = handler.initially ? (yield* handler.initially) : state.value
+      let ir = i.next()
+
+      while (!ir.done) {
+        if (matches(handler.effects, ir.value)) {
+          const hr: Step<any, any, any> = yield* handler.handle((ir.value), state.value as never) as any
+          switch (hr.tag) {
+            case 'return':
+              return handler.return ? handler.return(hr.value, state.value as never) : hr.value
+            case 'resume':
+              state.value = hr.state
+              ir = i.next(hr.value)
+              break
+          }
+        }
+        else if (is(Fork, ir.value))
+          ir = i.next(yield new Fork(ir.value.arg, [...ir.value.context, { handler, state, forkable }]))
+
+        else
+          ir = i.next(yield ir.value as any)
+      }
+
+      return handler.return ? handler.return(ir.value, state.value as never) : ir.value
+    } finally {
+      if (i.return) i.return()
+      if (handler.finally) yield* handler.finally(state.value as never)
+    }
+  }
+}
+
+export const matches = <const E extends Effects, const T>(e: E, t: T): t is Instance<E> =>
+  e.some(effectType => (t as any).id === effectType.id)
+
+export type Effects = readonly EffectType[]
+
+export type Instance<E extends Effects> = InstanceType<E[number]>

--- a/packages/fx/src/handler/internal/state.ts
+++ b/packages/fx/src/handler/internal/state.ts
@@ -1,0 +1,5 @@
+export type StateVar = {
+  value: unknown
+}
+
+export const empty = () => ({ value: undefined })

--- a/packages/fx/src/handler/step.ts
+++ b/packages/fx/src/handler/step.ts
@@ -1,0 +1,11 @@
+export type Step<A, R, S> = Resume<A, S> | Return<R>
+export type Resume<A, S = void> = { tag: 'resume'; value: A; state: S}
+export type Return<A> = { tag: 'return'; value: A}
+
+export function resume<const A>(a: A): Resume<A>
+export function resume<const A, const S>(a: A, s: S): Resume<A, S>
+export function resume<const A, const S>(a: A, s?: S): Resume<A, void | S> {
+  return ({ tag: 'resume', value: a, state: s }) as const
+}
+
+export const done = <const A>(a: A): Step<never, A, never> => ({ tag: 'return', value: a })

--- a/packages/fx/src/index.ts
+++ b/packages/fx/src/index.ts
@@ -1,6 +1,6 @@
 export * from './fx'
 
-export * as Handler from './handler/handler'
+export * as Handler from './handler'
 export * as Run from './run'
 
 export * as Async from './effects/async'


### PR DESCRIPTION
This goal is to simulate forked processes sharing the pre-fork portion of their parent's handler stack and state, rather than forking state.  It's hard to imagine a way to make forked state obvious, given that the state itself could be mutable.